### PR TITLE
Restructure project using src layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # document-ingestor
-A document ingestion pipeline for use with RAG-based workflows
+
+A document ingestion pipeline for use with RAG-based workflows.
+
+This project follows the `src` layout recommended in the documentation. All code
+lives under `src/document_ingestor` and tests are in `tests`.
+
+## Development
+
+Install dependencies using [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv venv
+uv sync
+```
+
+Run the command-line interface:
+
+```bash
+uv run document-ingestor
+```
+
+Run tests:
+
+```bash
+uv run pytest
+```

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from document-ingestor!")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,41 @@
+[build-system]
+requires = ["setuptools>=46.1.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "document-ingestor"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "requests>=2.28.0",
+    "numpy>=1.24.0",
+    "docling>=0.0.1",
+    "openai>=1.0.0",
+    "sentence-transformers>=2.2.0",
+    "qdrant-client>=1.7.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "ruff>=0.1.5",
+    "mypy>=1.8.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true

--- a/src/document_ingestor/__init__.py
+++ b/src/document_ingestor/__init__.py
@@ -1,0 +1,5 @@
+"""document-ingestor package."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/src/document_ingestor/main.py
+++ b/src/document_ingestor/main.py
@@ -1,0 +1,10 @@
+"""Command-line interface for document-ingestor."""
+
+
+def main() -> None:
+    """Entry point for the package."""
+    print("Hello from document-ingestor!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,7 @@
+from document_ingestor import main
+
+
+def test_main_output(capsys):
+    main()
+    captured = capsys.readouterr()
+    assert "Hello from document-ingestor!" in captured.out


### PR DESCRIPTION
## Summary
- move code into `src/document_ingestor`
- configure setuptools and lint/test tooling in pyproject
- document usage of uv for development
- add a simple CLI and expose it in `__init__`
- include an example pytest test

## Testing
- `ruff check`
- `uv pip install --system pytest` *(fails: No route to host)*