### PR TITLE
Add agent instructions for uv dependency management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Use [uv](https://github.com/astral-sh/uv) for package management.
+- When adding dependencies to this project, prefer `uv add <package>` instead of `uv pip install`. `uv add` updates `pyproject.toml` automatically and ensures that all dependencies are tracked.
+- Reserve `uv pip install` for temporary, one-off installations during development.


### PR DESCRIPTION
## Summary
- introduce `AGENTS.md` with guidelines on using `uv add` instead of `uv pip install`

## Testing
- `git status --short`