### PR TITLE
Add VS Code tasks for development

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,44 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Tests",
+            "type": "shell",
+            "command": "uv run pytest -v",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run Document Ingestor",
+            "type": "shell",
+            "command": "uv run document-ingestor",
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run Ruff",
+            "type": "shell",
+            "command": "uv run ruff .",
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Run Mypy",
+            "type": "shell",
+            "command": "uv run mypy src tests",
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Run tests:
 ```bash
 uv run pytest
 ```
+
+### VS Code Tasks
+
+Common development tasks are available via VS Code. Open the command palette and
+run `Tasks: Run Task` to see the options. Provided tasks include:
+
+- **Run Tests** – executes `uv run pytest -v`
+- **Run Document Ingestor** – starts the CLI with `uv run document-ingestor`
+- **Run Ruff** – lints the codebase with `uv run ruff .`
+- **Run Mypy** – performs type checking with `uv run mypy src tests`


### PR DESCRIPTION
## Summary
- add VS Code `tasks.json` with common tasks
- document how to use the tasks in the README

## Testing
- `uv run pytest -q` *(fails: No route to host)*